### PR TITLE
Fix index out of bounds error

### DIFF
--- a/gist/gist.go
+++ b/gist/gist.go
@@ -215,6 +215,8 @@ func (g *Gist) NewScreen() (s *Screen, err error) {
 		}
 		current = files[i].ID
 		switch {
+		case max == 0:
+			break
 		case i == 0:
 			previous = ""
 			next = files[i+1].ID


### PR DESCRIPTION
Thanks for cool tool :)  
When number of Gists is 1, index out of range error occurred in NewScreen method.   
I created a new case for fix the bug.