### PR TITLE
Do not save token in cache

### DIFF
--- a/pkg/gist/cache.go
+++ b/pkg/gist/cache.go
@@ -35,6 +35,9 @@ func (c *Cache) Save(pages []Page) error {
 	}
 	defer f.Close()
 	c.Pages = pages
+	// TODO: don't save token
+	// but better to think another solution to solve this
+	c.Token = ""
 	return json.NewEncoder(f).Encode(&c)
 }
 


### PR DESCRIPTION
## WHAT

Strip token info from cache before saving file

## WHY

It's not good